### PR TITLE
Change thumbnail creation logic.

### DIFF
--- a/Photo.Business/Utilities/ImagePreview/ImageThumbnailGenerator.cs
+++ b/Photo.Business/Utilities/ImagePreview/ImageThumbnailGenerator.cs
@@ -15,31 +15,18 @@ namespace Photo.Business.Utilities.ImagePreview {
 
             // Read from file
             using (var image = new MagickImage(imagePath)) {
-                var size = new MagickGeometry(width, height) { IgnoreAspectRatio = true };
-                // This will resize the image to a fixed size without maintaining the aspect ratio.
-                // Normally an image will be resized to fit inside the specified size.
-                if (IsResizeNeedsToApply(imagePath, width, height))
-                    image.Resize(size);
+                // Resize the image to fit inside the specified size.
+                if (image.Width > width || image.Height > height)
+                    image.Resize(width, height);
+
+                // Extent the image to the specified size.
+                image.Extent(width, height, Gravity.Center, MagickColors.Transparent);
+
                 var baseBath = RepositoryHelper.GetThumbnailFilePath(DocumentType.WorkFileUpload, type);
                 baseBath += fileId + "_" + width + "x" + height + ".png";
                 // Save the result
                 image.Write(baseBath);
             }
         }
-
-        /// <summary>
-        /// Read image metadata details
-        /// </summary>
-        /// <param name="imagePath"></param>
-        /// <param name="width"></param>
-        /// <param name="height"></param>
-        /// <returns></returns>
-        private static bool IsResizeNeedsToApply(string imagePath, int width, int height) {
-            // Read from file
-            var info = new MagickImageInfo(imagePath);
-            info.Read(imagePath);
-            return info.Width > width && info.Height > height;
-        }
-
     }
 }


### PR DESCRIPTION
The current code reads the image twice and it looks like the goal is to create an image that has a fixed size. This pull request changes the logic and fits the image inside the specified size and extents the image from the center to the specified size. Feel free to close this pull request if this is not your goal.